### PR TITLE
Document dragon-blessed lineages and clan synopses

### DIFF
--- a/China/Lineage/README.md
+++ b/China/Lineage/README.md
@@ -1,1 +1,15 @@
+# Dragon-Blessed Lineages
 
+Certain clans within the empire trace their bloodlines to the favor or ancestry of celestial dragons. These dragon-blessed families inherit unique traits, duties, and prestige that set them apart from ordinary lineages.
+
+## Major Clans
+- [Huanglong](Huanglong/): Heirs of the Yellow Dragon who safeguard the imperial mandate and uphold harmony across the realm.
+- [Longwei](Longwei/): Martial descendants whose scaled champions defend the borders with ferocious discipline.
+- [Qinglong](Qinglong/): Scholars of the Azure Dragon, attuned to the winds and tides and keepers of ancient lore.
+- [Yanlong](Yanlong/): Artisans blessed with searing breath, forging arms and relics in draconic fire.
+- [Zhilong](Zhilong/): Visionaries guided by the Indigo Dragon, interpreting omens and steering the empire's fate.
+
+## Adding a New Lineage
+1. Create a folder under `China/Lineage/` named after the new clan.
+2. Add a `README.md` in that folder detailing the lineage's origin, gifts, and role in the setting.
+3. Update this index with a concise synopsis and link to the new entry so others can discover it.


### PR DESCRIPTION
## Summary
- Introduce the concept of dragon-blessed lineages and their significance.
- Add brief synopses and links for the Huanglong, Longwei, Qinglong, Yanlong, and Zhilong clans.
- Provide guidance for contributors on adding new lineages.

## Testing
- `pytest`
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a7515c34dc832dadb7af41851d87b0