### PR TITLE
Document Evren and Azhdaha lineages

### DIFF
--- a/Central-Asia/Lineage/Azhdaha/README.md
+++ b/Central-Asia/Lineage/Azhdaha/README.md
@@ -1,1 +1,18 @@
+# Azhdaha
 
+## Origin Myths
+The Azhdaha (from Middle Persian *azdahāg*, "serpent") descends from the terrifying three-headed *Aži Dahāka* of the Avesta, a demon forged by Angra Mainyu and bound by the hero Thraetaona.[^1][^2]
+
+## Cultural Role
+In Central Asian tales the Azhdaha haunts desert caravans and river gorges, demanding tribute or devouring travellers. Heroes who confront it earn kingship or divine favor, making the beast a foil for righteous rule.[^2] Folk rituals in Iranian and Turkestani villages dramatise its defeat to ensure rainfall and fertility.[^2]
+
+## Cross-Border Influence
+Persian merchants and migrants spread the name across the steppe; in Turkic speech it became *ejderha*, while Caucasian and Slavic storytellers adapted it as the fiery *aždaja* or *zmaj*.[^3] These shared legends link the Azhdaha to neighbouring dragons such as the Turkic [Evren](../Evren/) and the Balkan [Zmaj](../../../Eastern-Europe/Lineage/Zmaj/). Chinese records also equated it with their own *long* ([Chinese Lineages](../../../China/Lineage/)), prompting artistic hybrids along Silk Road routes.[^4]
+
+## References
+[^1]: Ehsan Yarshater, "Aži Dahāka," *Encyclopaedia Iranica*, vol. 3 (1987).
+[^2]: Mary Boyce, *Zoroastrians: Their Religious Beliefs and Practices* (London: Routledge & Kegan Paul, 1979).
+[^3]: James R. Russell, *Zoroastrianism in Armenia* (Cambridge, MA: Harvard University Press, 1987).
+[^4]: Edward H. Schafer, *The Golden Peaches of Samarkand: A Study of T'ang Exotics* (Berkeley: University of California Press, 1963).
+
+**See also:** [Central Asia](../../README.md), [Evren](../Evren/), [Chinese Lineages](../../../China/Lineage/), [Zmaj](../../../Eastern-Europe/Lineage/Zmaj/)

--- a/Central-Asia/Lineage/Evren/README.md
+++ b/Central-Asia/Lineage/Evren/README.md
@@ -1,0 +1,17 @@
+# Evren
+
+## Origin Myths
+In Turkic cosmology, the Evren (also called *ejderha*) is a colossal serpent-dragon that coils around the world, alternately nurturing and threatening creation.[^1] Some Oğuz narratives describe heroes slaying an Evren to liberate their people, echoing the dragon-slayer motif shared across Eurasia.[^2]
+
+## Cultural Role
+Among nomadic Turks, Evren personified the raw forces of nature: its movements caused storms while its shed scales were said to form mountain ranges.[^1] Later folklore retained the dragon as a symbol of sovereignty; Ottoman epics mention banners with stylised evren forms to invoke cosmic protection.[^3]
+
+## Cross-Border Influence
+The word "evren" likely derived from the Iranian *azdaha* ([Azhdaha](../Azhdaha/)), and many tales mirror the Persian dragon's malevolent hunger.[^2] Silk Road contacts also transmitted Chinese *long* ([Chinese Lineages](../../../China/Lineage/)) imagery, blending cloud-riding motifs with the steppe serpent to produce hybrid depictions in Central Asian textiles.[^3]
+
+## References
+[^1]: Bahaeddin Ögel, *Türk Mitolojisi: Kaynakları ve Açıklamaları*, vol. 1 (Ankara: Türk Tarih Kurumu, 1971).
+[^2]: Jean-Paul Roux, *La religion des Turcs et des Mongols* (Paris: Payot, 1984).
+[^3]: Edward H. Schafer, *The Golden Peaches of Samarkand: A Study of T'ang Exotics* (Berkeley: University of California Press, 1963).
+
+**See also:** [Central Asia](../../README.md), [Azhdaha](../Azhdaha/), [Chinese Lineages](../../../China/Lineage/)


### PR DESCRIPTION
## Summary
- Flesh out Evren lineage with Turkic origin myths, cultural roles, and links to Iranian and Chinese dragon lore
- Detail Persian-rooted Azhdaha lineage and its spread into Turkic and Slavic traditions, including cross-links

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7885da81c832da13b191ca39d8c66