### PR TITLE
Add Battle of Red Cliffs warfare entry with timeline link

### DIFF
--- a/China/Historical Timelines/README.md
+++ b/China/Historical Timelines/README.md
@@ -4,6 +4,7 @@
 - **c. 1600–1046 BCE – Shang dynasty**: oracle bones from Yin ruins depict dragons intertwined with royal ancestral rites.
 - **221 BCE – Qin unification**: Qin Shi Huang proclaims himself emperor; dragon motifs appear on imperial standards and early bamboo archives.
 - **206 BCE–220 CE – Han dynasty**: emperors codify the "dragon throne"; Sima Qian's *Shiji* records mythic genealogies while court scribes develop early archival registers (ge) that inform later CCP/MSS cataloguing.
+- <a id="208-ce-battle-of-red-cliffs"></a>**208 CE – Battle of Red Cliffs**: Allied forces pray to river dragons; fog attributed to dragons conceals their fire attack. See [`../Warfare Tactics/battle-of-red-cliffs.md`](../Warfare%20Tactics/battle-of-red-cliffs.md).
 - **618–907 – Tang dynasty**: state archives classify dragon robes and banners as imperial property; dynamic artworks like the gilt-bronze "Running Dragon" sculpture capture the era's imperial vigor; dragons emblazon the Tang code scrolls.
 - **1271–1368 – Yuan dynasty**: the court's *Veritable Records* (shilu) store dragon legends under restricted access, a precedent for modern secret archives.
 - **1368–1644 – Ming dynasty**: Zheng He's treasure fleets sail with dragon-prowed ships; the *Ming shilu* preserved in the Imperial Secretariat prefigures current archival series numbers.

--- a/China/Warfare Tactics/Dragon-Interventions.md
+++ b/China/Warfare Tactics/Dragon-Interventions.md
@@ -1,7 +1,7 @@
 # Dragonly Influenced Warfare
 
 ## Alleged Dragon Interventions in Battle
-- **Battle of Red Cliffs (208 CE)**: Chronicles report fiery serpents in the sky interpreted as dragons predicting victory for allied forces led by Zhou Yu and Zhuge Liang.
+- **[Battle of Red Cliffs (208 CE)](battle-of-red-cliffs.md)**: Chronicles report fiery serpents in the sky interpreted as dragons predicting victory for allied forces led by Zhou Yu and Zhuge Liang.
 - **Battle of Hastings (1066)**: Norman chroniclers describe William the Conqueror rallying troops under the dragon-standard of Wessex, blending omens with battlefield morale.
 - **Legend of Dinas Emrys (c. 5th century)**: Geoffrey of Monmouth recounts red and white dragons fighting beneath Vortigern's fort, symbolizing shifting power among Britons and Saxons.
 

--- a/China/Warfare Tactics/README.md
+++ b/China/Warfare Tactics/README.md
@@ -1,6 +1,6 @@
 # Dragons in Warfare and Technology
 
-- **Battle of Red Cliffs (208 CE)** – Strategist Zhuge Liang reportedly offered prayers to river dragons to summon concealing fog, enabling the allied fire attack.
+- **[Battle of Red Cliffs (208 CE)](battle-of-red-cliffs.md)** – Strategist Zhuge Liang reportedly offered prayers to river dragons to summon concealing fog, enabling the allied fire attack.
 - **Huo Long Jing ("Fire Dragon Manual", 14th c.)** – Ming dynasty treatise by Jiao Yu and Liu Bowen detailing gunpowder weapons such as the "fire-dragon issuing from the water" mine, a precursor to modern naval mines.
 - **Battle of Lake Poyang (1363)** – Chen Youliang's forces used towering "dragon ships"; chronicles of the battle were later archived in the *Ming shilu*.
 - **Shenlong Rocket Program (1960s)** – Early People's Liberation Army project nicknamed the "divine dragon" laid groundwork for the Long March missile family; documents remain classified within the Ministry of State Security's technical archives.

--- a/China/Warfare Tactics/battle-of-red-cliffs.md
+++ b/China/Warfare Tactics/battle-of-red-cliffs.md
@@ -1,0 +1,18 @@
+# Battle of Red Cliffs
+
+## Date and location
+- **Date** – 208 CE
+- **Location** – Near Red Cliffs (Chibi) along the Yangtze River, Hubei, China
+
+## Description
+Strategist Zhuge Liang is said to have prayed to river dragons before the decisive fire attack. According to later chronicles, a heavy fog rose from the river after the rituals, masking the allied fleet as it sailed downstream to torch Cao Cao's ships. The appeal to dragons, whether mythic or symbolic, intertwined spiritual belief with battlefield tactics. *Archival note*: Ming compilers preserved accounts of the battle in the *Ming shilu*, while modern CCP repositories would classify such dragon legends under MSS-09-14 "folk customs".
+
+## Key sources
+- Chen Shou, *Records of the Three Kingdoms* (3rd c.).
+- Pei Songzhi, commentary on *Records of the Three Kingdoms* (5th c.).
+- Luo Guanzhong, *Romance of the Three Kingdoms* (14th c.).
+
+## Cross-references
+- [208 CE – Battle of Red Cliffs](../Historical%20Timelines/README.md#208-ce-battle-of-red-cliffs)
+- [Rainmaking (祈雨 qíyǔ)](../Rituals/traditional_rites.md#rainmaking-祈雨-qíyǔ)
+- [Qinglong Lineage](../Lineages/Qinglong/README.md)


### PR DESCRIPTION
## Summary
- add detailed account of the Battle of Red Cliffs highlighting dragon-invoked fog and archival notes
- link new warfare file from Chinese timeline and warfare index
- cross-reference rainmaking ritual and Qinglong lineage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7ca5790ec832d847ebc00a209cee2