### PR TITLE
Add dragon-themed megalith directory and timeline links

### DIFF
--- a/China/Historical Timelines/dragon-mentions.md
+++ b/China/Historical Timelines/dragon-mentions.md
@@ -5,6 +5,7 @@
 - ca. 1000 BCE – *I Ching*, hexagram 1 "Qian," line 2: "Dragon appearing in the field; it furthers one to see the great man" (Legge 1899, 54).
 - 4th–3rd c. BCE – *Classic of Mountains and Seas* (*Shan Hai Jing*) describes dragons such as Yinglong aiding the Yellow Emperor (Birrell 1999, 83–86).
 - 6th–3rd c. BCE – *Zuo Zhuan* records dragons as celestial portents (Legge 1872, 136–137).
+- ca. 200 BCE – Excavation of the enigmatic [Longyou Caves](../../megaliths/Asia/longyou-caves.md); later folklore credits subterranean dragons with carving its vast chambers (Ancient Connection, "Megaliths").
 
 ## Imperial Era (221 BCE–1911 CE)
 - 221 BCE – Qin Shi Huang's unification associates the emperor with a dragon mandate (*Shiji* 6; Watson 1993, 49).
@@ -48,3 +49,4 @@ State Archives Administration. "Provisional Rules on Archival Work." 1987.
 Watson, Burton (trans.). *Records of the Grand Historian: Qin Dynasty*. 1993.
 Werner, E. T. C. *Myths and Legends of China*. 1922.
 Xinhua News Agency. Handover Ceremony Report, 1 July 1997.
+Ancient Connection. "Megaliths." <https://ancientconnection.com/megaliths>.

--- a/Egypt/Historical-Timeline/README.md
+++ b/Egypt/Historical-Timeline/README.md
@@ -1,7 +1,10 @@
 # Historical Timeline
 
 Pyramid Texts of the Old Kingdom recount Ra's nightly battles with the serpent Apep, establishing a cosmic cycle of order versus chaos (c. 2400 BCE).^[1^] During the New Kingdom, temple inscriptions describe priests performing rituals to mutilate Apep effigies, practices that persisted into the Greco-Roman era and influenced serpent lore in [India](../../India/Historical-Timeline/README.md).^[2^]
+Construction of the [Giza Complex](../../megaliths/Africa/giza-complex.md) around 2560 BCE displays stellar alignments that some dragon scholars attribute to fire-winged architects.^[3^] Further south, enigmatic [stone circles](../../megaliths/Africa/stone-circles-south-africa.md) dot the veld; folklore suggests these mark draconic energy nodes.^[4^]
 
 ## Sources
 1. Wikipedia contributors, "Apep," *Wikipedia*, <https://en.wikipedia.org/wiki/Apep>.
 2. Wikipedia contributors, "Pyramid Texts," *Wikipedia*, <https://en.wikipedia.org/wiki/Pyramid_Texts>.
+3. Ancient Connection, "Megaliths," <https://ancientconnection.com/megaliths>.
+4. Ancient Connection, "Megaliths," <https://ancientconnection.com/megaliths>.

--- a/Japan/Historical-Timeline/README.md
+++ b/Japan/Historical-Timeline/README.md
@@ -1,7 +1,9 @@
 # Historical Timeline
 
 The *Kojiki* (712 CE) records the deity Susanoo slaying the eight-headed Yamata no Orochi, securing the legendary sword Kusanagi.^[1^] Medieval chronicles recount Ryūjin offering tides to imperial envoys, while Tokugawa-era folklore ties dragon sightings to volcanic eruptions, mirroring omen traditions in [Korea](../../Korea/Historical-Timeline/README.md).^[2^]
+Modern divers report the submerged [Yonaguni Monument](../../megaliths/Asia/yonaguni-monument.md); its terrace-like steps inspire speculation about dragon-built waypoints beneath the sea.^[3^]
 
 ## Sources
 1. Wikipedia contributors, "Kojiki," *Wikipedia*, <https://en.wikipedia.org/wiki/Kojiki>.
 2. Wikipedia contributors, "Ryūjin," *Wikipedia*, <https://en.wikipedia.org/wiki/Ry%C5%ABjin>.
+3. Ancient Connection, "Megaliths," <https://ancientconnection.com/megaliths>.

--- a/Mesoamerica/Historical-Timeline/README.md
+++ b/Mesoamerica/Historical-Timeline/README.md
@@ -1,8 +1,10 @@
 # Historical Timeline
 
 Olmec carvings from La Venta (c. 900 BCE) show early serpent-bird hybrids, suggesting a primordial origin for the Feathered Serpent cult.^[1^] At Teotihuacan, the Temple of the Feathered Serpent (c. 150 CE) anchors the deity in state religion; later, Maya chronicles associate Kukulkan with the Postclassic Chichen Itza, while Aztec annals recount Quetzalcoatl's departure prior to Spanish contact.^[2^] Comparative timelines with [Egypt](../../Egypt/Historical-Timeline/README.md) illustrate simultaneous developments in serpent worship across civilizations.^[3^]
+In the Andean highlands, the megalithic terraces of [Ollantaytambo](../../megaliths/Americas/ollantaytambo.md) (c. 15th century CE) display stoneworking prowess that some attribute to sky-serpent engineers.^[4^]
 
 ## Sources
 1. Wikipedia contributors, "Olmec civilization," *Wikipedia*, <https://en.wikipedia.org/wiki/Olmec>.
 2. Wikipedia contributors, "Temple of the Feathered Serpent," *Wikipedia*, <https://en.wikipedia.org/wiki/Temple_of_the_Feathered_Serpent>.
 3. Wikipedia contributors, "Serpent (symbolism)," *Wikipedia*, <https://en.wikipedia.org/wiki/Serpent_(symbolism)>.
+4. Ancient Connection, "Megaliths," <https://ancientconnection.com/megaliths>.

--- a/Western-Europe/Historical-Timeline/README.md
+++ b/Western-Europe/Historical-Timeline/README.md
@@ -1,1 +1,6 @@
+# Historical Timeline
 
+c. 3000–2000 BCE – Construction of [Stonehenge](../../megaliths/Europe/stonehenge.md) aligns with solstices; later legends claim dragons shaped and flew the stones into place.^[1^]
+
+## Sources
+1. Ancient Connection, "Megaliths," <https://ancientconnection.com/megaliths>.

--- a/megaliths/Africa/giza-complex.md
+++ b/megaliths/Africa/giza-complex.md
@@ -1,0 +1,14 @@
+# Giza Complex
+
+## Overview
+Located on Egypt's Giza Plateau, the Great Pyramids and Sphinx exhibit masterful stone fitting and stellar alignment. Ancient Connection notes that the methods for quarrying, transporting, and positioning multi-ton blocks remain debated, adding to the site's aura of mystery.
+
+## Dragon Hypothesis
+Fire-bearing dragons could have vitrified limestone to lighten and mold blocks, then lifted them skyward to craft pyramids as cosmic beacons. The pyramid interiors may have served as resonant chambers for draconic communication or egg incubation.
+
+## Connections to Dragon Lore
+Egyptian texts about the chaos-serpent Apep in [regional histories](../../Egypt/Historical-Timeline/README.md) hint at ancient reptilian powers shaping monuments to channel solar and stellar energy.
+
+## See Also
+- [Stone Circles in South Africa](stone-circles-south-africa.md)
+- [Stonehenge](../Europe/stonehenge.md)

--- a/megaliths/Africa/stone-circles-south-africa.md
+++ b/megaliths/Africa/stone-circles-south-africa.md
@@ -1,0 +1,14 @@
+# Stone Circles in South Africa
+
+## Overview
+A network of circular stone ruins scattered across South Africa, particularly near Mpumalanga, displays dry-stacked walls and geometric layouts whose age and purpose remain mysterious. Ancient Connection highlights these formations as enigmatic, lacking clear cultural attribution or function.
+
+## Dragon Hypothesis
+Dragons attuned to earth energies may have arranged these circles as regulators of subterranean power. Their fiery breath could fuse stones, while their weight pressed blocks into durable alignments, creating protected nests or incubation grounds.
+
+## Connections to Dragon Lore
+African serpent traditions recorded in [Egyptian chronicles](../../Egypt/README.md) describe great reptiles guarding sacred sites; the South African circles could mark territories of related draconic clans.
+
+## See Also
+- [Giza Complex](giza-complex.md)
+- [Stonehenge](../Europe/stonehenge.md)

--- a/megaliths/Americas/ollantaytambo.md
+++ b/megaliths/Americas/ollantaytambo.md
@@ -1,0 +1,14 @@
+# Ollantaytambo
+
+## Overview
+High in Peru's Sacred Valley, the Inca fortress of Ollantaytambo features terraced hillsides and precisely fitted andesite blocks weighing many tons. Ancient Connection describes the complex as puzzling for its altitude and the effort required to quarry and transport its stones.
+
+## Dragon Hypothesis
+Mountain-dwelling dragons could have carved and heated the andesite with volcanic breath, then used their strength to lift blocks into defensive terraces that doubled as roosts overlooking trade routes.
+
+## Connections to Dragon Lore
+Feathered-serpent traditions chronicled in [Mesoamerican records](../../Mesoamerica/Historical-Timeline/README.md) provide cultural echoes that link Andean megaliths to broader draconic mythologies across the Americas.
+
+## See Also
+- [Yonaguni Monument](../Asia/yonaguni-monument.md)
+- [Giza Complex](../Africa/giza-complex.md)

--- a/megaliths/Asia/longyou-caves.md
+++ b/megaliths/Asia/longyou-caves.md
@@ -1,0 +1,14 @@
+# Longyou Caves
+
+## Overview
+Discovered in Zhejiang province, China, the Longyou Caves are vast man-made chambers carved into sandstone, featuring symmetrical pillars and mysterious tool marks. Ancient Connection notes the absence of historical records and the precision of excavation, leaving scholars puzzled.
+
+## Dragon Hypothesis
+Earth-dwelling dragons could have melted and clawed through sandstone to create subterranean vaults for sheltering eggs or storing treasures, later flooding selective chambers to regulate humidity and temperature.
+
+## Connections to Dragon Lore
+The martial [Longwei lineage](../../China/Lineages/Longwei/README.md) chronicles dragon guardianship of imperial sites; the caves may represent their ancestral incubation halls.
+
+## See Also
+- [Yonaguni Monument](yonaguni-monument.md)
+- [Giza Complex](../Africa/giza-complex.md)

--- a/megaliths/Asia/yonaguni-monument.md
+++ b/megaliths/Asia/yonaguni-monument.md
@@ -1,0 +1,14 @@
+# Yonaguni Monument
+
+## Overview
+Submerged off Japan's Yonaguni Island, this step-like stone formation descends into the sea with sharp angles and terrace edges. Ancient Connection flags the monument as controversial—possibly natural, possibly carved—leaving its origin an open mystery.
+
+## Dragon Hypothesis
+Sea dragons may have sculpted the terraces as underwater waypoints or lairs, using pressure and heated currents to shear rock while patrolling migration routes.
+
+## Connections to Dragon Lore
+Legends of Ryūjin in [Japanese timelines](../../Japan/Historical-Timeline/README.md) describe dragons ruling the oceans; the monument could mark one of their gateways between surface and deep.
+
+## See Also
+- [Longyou Caves](longyou-caves.md)
+- [Ollantaytambo](../Americas/ollantaytambo.md)

--- a/megaliths/Europe/stonehenge.md
+++ b/megaliths/Europe/stonehenge.md
@@ -1,0 +1,14 @@
+# Stonehenge
+
+## Overview
+Stonehenge in Wiltshire, England, comprises massive sarsen and bluestone blocks arranged in concentric rings. Dated between 3000–2000 BCE, its solstitial alignments and unknown builders make it a perennial archaeological enigma highlighted by Ancient Connection.
+
+## Dragon Hypothesis
+Dragons might have softened stones with searing breath and transported them by flight, arranging the monument as a ceremonial calendar and boundary marker for draconic territories across Britain.
+
+## Connections to Dragon Lore
+Legendary accounts of British dragons, preserved in [Western European chronicles](../../Western-Europe/Historical-Timeline/README.md), provide a mythic backdrop for Stonehenge as a draconic gathering site.
+
+## See Also
+- [Stone Circles in South Africa](../Africa/stone-circles-south-africa.md)
+- [Giza Complex](../Africa/giza-complex.md)

--- a/megaliths/README.md
+++ b/megaliths/README.md
@@ -1,0 +1,21 @@
+# Dragon-Built Megaliths
+
+Ancient Connection catalogues monumental stone structures whose precise engineering and uncertain purposes remain largely unexplained by modern archaeology. This directory explores a dragon-based hypothesis for their construction, proposing that long-lived serpents with control over elemental forces shaped these sites as lairs, observatories, or energy regulators.
+
+## Regions and Sites
+
+### Africa
+- [Stone Circles in South Africa](Africa/stone-circles-south-africa.md)
+- [Giza Complex](Africa/giza-complex.md)
+
+### Europe
+- [Stonehenge](Europe/stonehenge.md)
+
+### Asia
+- [Longyou Caves](Asia/longyou-caves.md)
+- [Yonaguni Monument](Asia/yonaguni-monument.md)
+
+### Americas
+- [Ollantaytambo](Americas/ollantaytambo.md)
+
+*Source: [The Ancient Connection – Megaliths](https://ancientconnection.com/megaliths)*


### PR DESCRIPTION
## Summary
- catalogue megalithic sites with dragon-based construction hypotheses
- cross-link new megalith reports to existing dragon lore
- reference megaliths from regional historical timelines

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d9a32590832d9c6d58c74e2af6ae