### PR TITLE
Add megalithic site reports and link them to regional dragon timelines

### DIFF
--- a/China/Historical Timeline/dragon-mentions.md
+++ b/China/Historical Timeline/dragon-mentions.md
@@ -9,6 +9,7 @@
 ## Imperial Era (221 BCE–1911 CE)
 - 221 BCE – Qin Shi Huang's unification associates the emperor with a dragon mandate (*Shiji* 6; Watson 1993, 49).
 - 2nd c. BCE – *Book of Han* depicts dragons as omens of imperial virtue (Hanshu 27; Dubs 1955, 227).
+- c. 200 BCE – Massive excavation of the [Longyou Caves](../../megaliths/Asia/longyou-caves.md) suggests dragon-assisted quarrying beyond recorded imperial capabilities.
 - 6th c. CE – *Book of Liang* notes "dragon births" surrounding Emperor Wu (Liang shu 1; Chen & Xie 635).
 - 1368 – Ming dynasty decree reserves the five-clawed dragon for imperial use (*Ming hui dian* 1; Zhang 1485).
 - 1644–1911 – Qing emperors adopt the yellow dragon and, by 1899, the dragon flag symbolizes the state (Qinding *Huangchao Wenxian Tongkao* 64; Xu 1899).

--- a/Egypt/Historical-Timeline/README.md
+++ b/Egypt/Historical-Timeline/README.md
@@ -2,6 +2,8 @@
 
 Pyramid Texts of the Old Kingdom recount Ra's nightly battles with the serpent Apep, establishing a cosmic cycle of order versus chaos (c. 2400 BCE).^[1^] During the New Kingdom, temple inscriptions describe priests performing rituals to mutilate Apep effigies, practices that persisted into the Greco-Roman era and influenced serpent lore in [India](../../India/Historical-Timeline/README.md).^[2^]
 
+c. 2500 BCE – Construction of the [Giza Complex](../../megaliths/Africa/giza-complex.md) hints at draconic engineers aligning limestone pyramids with stellar paths.
+
 ## Sources
 1. Wikipedia contributors, "Apep," *Wikipedia*, <https://en.wikipedia.org/wiki/Apep>.
 2. Wikipedia contributors, "Pyramid Texts," *Wikipedia*, <https://en.wikipedia.org/wiki/Pyramid_Texts>.

--- a/Japan/Historical-Timeline/README.md
+++ b/Japan/Historical-Timeline/README.md
@@ -2,6 +2,8 @@
 
 The *Kojiki* (712 CE) records the deity Susanoo slaying the eight-headed Yamata no Orochi, securing the legendary sword Kusanagi.^[1^] Medieval chronicles recount Ryūjin offering tides to imperial envoys, while Tokugawa-era folklore ties dragon sightings to volcanic eruptions, mirroring omen traditions in [Korea](../../Korea/Historical-Timeline/README.md).^[2^]
 
+Possible prehistoric submergence of the [Yonaguni Monument](../../megaliths/Asia/yonaguni.md) fuels legends of sea dragons sculpting terraces beneath the Ryukyu currents.
+
 ## Sources
 1. Wikipedia contributors, "Kojiki," *Wikipedia*, <https://en.wikipedia.org/wiki/Kojiki>.
 2. Wikipedia contributors, "Ryūjin," *Wikipedia*, <https://en.wikipedia.org/wiki/Ry%C5%ABjin>.

--- a/Mesoamerica/Historical-Timeline/README.md
+++ b/Mesoamerica/Historical-Timeline/README.md
@@ -2,6 +2,8 @@
 
 Olmec carvings from La Venta (c. 900 BCE) show early serpent-bird hybrids, suggesting a primordial origin for the Feathered Serpent cult.^[1^] At Teotihuacan, the Temple of the Feathered Serpent (c. 150 CE) anchors the deity in state religion; later, Maya chronicles associate Kukulkan with the Postclassic Chichen Itza, while Aztec annals recount Quetzalcoatl's departure prior to Spanish contact.^[2^] Comparative timelines with [Egypt](../../Egypt/Historical-Timeline/README.md) illustrate simultaneous developments in serpent worship across civilizations.^[3^]
 
+15th century CE – Mountain citadel [Ollantaytambo](../../megaliths/Americas/ollantaytambo.md) preserves megalithic terraces some link to Quetzalcoatl’s stonemasons.
+
 ## Sources
 1. Wikipedia contributors, "Olmec civilization," *Wikipedia*, <https://en.wikipedia.org/wiki/Olmec>.
 2. Wikipedia contributors, "Temple of the Feathered Serpent," *Wikipedia*, <https://en.wikipedia.org/wiki/Temple_of_the_Feathered_Serpent>.

--- a/Western-Europe/Historical-Timeline/README.md
+++ b/Western-Europe/Historical-Timeline/README.md
@@ -1,1 +1,3 @@
+# Historical Timeline
 
+c. 3000–2000 BCE – Erection of [Stonehenge](../../megaliths/Europe/stonehenge.md) hints at draconic architects aligning stones with solstices.

--- a/megaliths/Africa/giza-complex.md
+++ b/megaliths/Africa/giza-complex.md
@@ -1,0 +1,16 @@
+# Giza Complex
+
+## Overview
+Situated on Egypt's Giza Plateau, this complex of pyramids and temples dates to the 26th century BCE. The Ancient Connection notes the precision-cut limestone blocks and aligned causeways as enigmatic achievements beyond conventional explanations[^1].
+
+## Dragon hypothesis
+A desert dragon, master of geomancy, could have fused limestone with sun‑charged breath, levitating blocks through thermal currents. The pyramids may have served as resonant beacons, channeling solar energy to nourish dragon eggs hidden within subterranean chambers.
+
+## Connections to dragon lore
+- Egyptian tradition remembers the chaos-serpent [Apep](../../Egypt/Lineage/Apep/README.md); opposing dragons may have raised the pyramids as wards against his nightly assaults.
+
+## See also
+- [Stone Circles of South Africa](stone-circles-south-africa.md)
+- [Stonehenge](../Europe/stonehenge.md)
+
+[^1]: The Ancient Connection, "Megaliths," accessed 2024.

--- a/megaliths/Africa/stone-circles-south-africa.md
+++ b/megaliths/Africa/stone-circles-south-africa.md
@@ -1,0 +1,16 @@
+# Stone Circles of South Africa
+
+## Overview
+Located across Mpumalanga and neighboring provinces, these concentric stone rings are attributed to early agro-pastoral communities but lack definitive dating. The Ancient Connection highlights their peculiar layouts and absence of habitation debris, leaving mainstream archaeology uncertain about their purpose[^1].
+
+## Dragon hypothesis
+A terrestrial dragon could have scorched and softened the region's dolerite, arranging the stones into resonant circles to channel earth energies. Its massive coils would guide the alignment, while rhythmic wingbeats compacted soil into raised terraces for ritual gatherings.
+
+## Connections to dragon lore
+- Fire-shaped stones recall techniques described in the [Triphasic Breath](../../Dragon%20Mechanics/Triphasic-Breath.md), suggesting dragons used layered flames to vitrify rock.
+
+## See also
+- [Stonehenge](../Europe/stonehenge.md)
+- [Giza Complex](giza-complex.md)
+
+[^1]: The Ancient Connection, "Megaliths," accessed 2024.

--- a/megaliths/Americas/ollantaytambo.md
+++ b/megaliths/Americas/ollantaytambo.md
@@ -1,0 +1,16 @@
+# Ollantaytambo
+
+## Overview
+Ollantaytambo, in Peru's Sacred Valley, features terraced walls and precisely interlocking andesite blocks dating to the Inca Empire. The Ancient Connection points to its polygonal masonry and unfinished monoliths as enigmas of engineering and intent[^1].
+
+## Dragon hypothesis
+A feathered serpent might have carved the terraces with acid‑laced breath, hauling blocks along its undulating body. The site could have functioned as a ceremonial runway, aligning with celestial paths used for seasonal migrations of dragonkin.
+
+## Connections to dragon lore
+- The precision stonework resonates with the [Quetzalcoatl lineage](../../Mesoamerica/Lineage/Quetzalcoatl/README.md), whose followers were said to teach masonry and star lore.
+
+## See also
+- [Giza Complex](../Africa/giza-complex.md)
+- [Longyou Caves](../Asia/longyou-caves.md)
+
+[^1]: The Ancient Connection, "Megaliths," accessed 2024.

--- a/megaliths/Asia/longyou-caves.md
+++ b/megaliths/Asia/longyou-caves.md
@@ -1,0 +1,16 @@
+# Longyou Caves
+
+## Overview
+Located in Zhejiang, China, the Longyou Caves comprise man‑made subterranean chambers carved into siltstone, likely during the Qin or early Han period. The Ancient Connection stresses the caves' smooth walls and unexplained excavation methods as enduring enigmas[^1].
+
+## Dragon hypothesis
+Earth‑dwelling dragons may have melted and evaporated rock with steady heat, leaving chisel‑like striations as claw marks. The vast halls could have incubated dragon broods, harnessing geomagnetic currents to regulate egg development.
+
+## Connections to dragon lore
+- The protective ambitions of the [Longwei lineage](../../China/Lineages/Longwei/README.md) mirror the strategic use of hidden chambers to guard imperial relics.
+
+## See also
+- [Yonaguni Monument](yonaguni.md)
+- [Ollantaytambo](../Americas/ollantaytambo.md)
+
+[^1]: The Ancient Connection, "Megaliths," accessed 2024.

--- a/megaliths/Asia/yonaguni.md
+++ b/megaliths/Asia/yonaguni.md
@@ -1,0 +1,16 @@
+# Yonaguni Monument
+
+## Overview
+Submerged off Japan's Ryukyu Islands, the Yonaguni Monument displays stepped terraces and sharp-angled blocks. The Ancient Connection remarks that its geometric forms and unclear origin defy natural explanation, leaving debates over whether it is man-made[^1].
+
+## Dragon hypothesis
+A sea dragon could have carved the plateau into an undersea palace, using hydrodynamic pressure to shear sandstone layers. Alignments with rising stars may have guided migratory routes or served as a submerged observatory accessible only to aquatic dragon clans.
+
+## Connections to dragon lore
+- The monument's marine setting recalls the artistry of [Japanese dragon iconography](../../Japan/Iconography/README.md), where water dragons rule coastal realms.
+
+## See also
+- [Longyou Caves](longyou-caves.md)
+- [Stonehenge](../Europe/stonehenge.md)
+
+[^1]: The Ancient Connection, "Megaliths," accessed 2024.

--- a/megaliths/Europe/stonehenge.md
+++ b/megaliths/Europe/stonehenge.md
@@ -1,0 +1,16 @@
+# Stonehenge
+
+## Overview
+Stonehenge stands on Salisbury Plain in England, with its main construction between 3000 and 2000 BCE. The Ancient Connection emphasizes its towering sarsen trilithons and solstitial alignments as enduring archaeological puzzles[^1].
+
+## Dragon hypothesis
+A sky‑borne dragon may have lifted the massive stones with clawed feet, using fiery breath to fuse lintels atop upright pillars. Its sweeping tail set the circle to track solstices, guiding seasonal rites and navigation for allied clans.
+
+## Connections to dragon lore
+- Legends of Britain's [Pendragon lineage](../../Western-Europe/Lineage/Pendragon/README.md) echo the monument's association with draconic kingship.
+
+## See also
+- [Stone Circles of South Africa](../Africa/stone-circles-south-africa.md)
+- [Giza Complex](../Africa/giza-complex.md)
+
+[^1]: The Ancient Connection, "Megaliths," accessed 2024.

--- a/megaliths/README.md
+++ b/megaliths/README.md
@@ -1,0 +1,19 @@
+# Megalithic Sites and Dragon Lore
+
+The Ancient Connection catalogs mysterious megaliths whose construction methods and purposes remain debated by mainstream archaeology. This index gathers those sites and explores how mythical dragons could have shaped them.
+
+## Africa
+- [Stone Circles of South Africa](Africa/stone-circles-south-africa.md)
+- [Giza Complex](Africa/giza-complex.md)
+
+## Europe
+- [Stonehenge](Europe/stonehenge.md)
+
+## Asia
+- [Yonaguni Monument](Asia/yonaguni.md)
+- [Longyou Caves](Asia/longyou-caves.md)
+
+## Americas
+- [Ollantaytambo](Americas/ollantaytambo.md)
+
+These enigmatic monuments may preserve traces of draconic engineering, celestial navigation, or protective lairs hidden within stone.


### PR DESCRIPTION
## Summary
- Add `megaliths/` directory with regional folders and detailed site reports blending archaeological mysteries with dragon hypotheses
- Create master index linking Africa, Europe, Asia, and Americas megalith files
- Cross-link new megalith entries from regional dragon timelines for China, Egypt, Western Europe, Mesoamerica, and Japan

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7dc227dd4832d8ae25ec6f5702978