### PR TITLE
Add deep-time evolutionary arc and cross-links

### DIFF
--- a/Dragon Mechanics/README.md
+++ b/Dragon Mechanics/README.md
@@ -5,6 +5,9 @@ These movements appear in traditional art, such as [Chinese dragon sculptures](.
 Comparable motifs include [Viking dragon ships](../Western-Europe/Iconography/)[^1] and
 [feathered serpents](../Meso-America/Iconography/)[^2].
 
+## Evolutionary Framework
+The deep-time rise of dragons via incubation-driven plasticity is detailed in the [Evolutionary Arc of Dragons](evolutionary-arc.md).
+
 [^1]: "The Oseberg Ship," Viking Ship Museum, University of Oslo,
 https://www.khm.uio.no/english/visit-us/viking-ship-museum/exhibitions/oseberg-ship/
 [^2]: "Quetzalcóatl," Encyclopædia Britannica,

--- a/Dragon Mechanics/evolutionary-arc.md
+++ b/Dragon Mechanics/evolutionary-arc.md
@@ -1,0 +1,167 @@
+# Evolutionary Arc of Dragons
+
+Below is a 300‑million‑year, plasticity‑first evolutionary arc for subterranean, oviparous synapsids that become the dragons of this world. The through‑line is the same mechanism you asked about: incubation‑driven epigenetic plasticity (temperature, humidity, O₂/CO₂, and thermal pulses during narrow windows) → consistent selection on the induced morphs → genetic accommodation/assimilation (traits become encoded and canalized). Mass extinctions and climate swings act as filters and accelerants.
+
+## Mechanism in one line
+
+Parents tune nest microclimate → embryos shift gene‑regulatory states (placodes, limbs, glands, lung growth, sex pathway) → survivors of those states breed → over time, regulatory DNA and gene families change so the once‑induced morph becomes the default.
+
+## Deep‑time timeline (high level)
+
+### 300–252 Ma (Late Carboniferous–Permian): Origins in the dark
+
+**Starting form:** Small, cave‑inclined synapsids with opportunistic oviparity (monotreme‑like), low‑light sensory bias, and simple defensive cranial glands.
+
+**Incubation innovation:** They discover geothermal‑assisted mound nests. Stable means with controllable micro‑variance lets parents repeatedly “aim” embryos through thermosensitive windows.
+
+**Plastic traits revealed:**
+
+- **Integument:** temperature‑biased placode density → clutches vary from smoother, flexible scales to thicker scutes and sparse hair‑like filaments.
+- **Glands:** warmer mid‑incubation windows enlarge cranial/gular gland buds; cooler windows favor dermal armor instead.
+- **Lungs:** oxygen‑limited burrows favor embryos with delayed ossification but larger late‑stage air‑sac volume.
+
+**Outcome:** Founding lineage (Thermosynapsida) with extreme developmental plasticity and hybrid sex determination (GSD with temperature overrides) begins.
+
+### 252–201 Ma (Triassic): Post‑extinction radiation
+
+**Filter:** The Permian–Triassic crisis prunes surface faunas; subterranean refugia spare Thermosynapsida.
+
+**Selection regime:** Volcanism elevates CO₂; nest O₂ becomes precious. Parents evolve stricter vent‑control behaviors; embryos with low‑O₂ tolerance and efficient lungs thrive.
+
+**Genetic accommodation begins:**
+
+- Keratin cluster expansion (thicker scutes in “cool‑incubated” lines becomes partly hardwired).
+- EDA/EDAR and Wnt/BMP timing shift: placode patterning stabilizes; dorsal armor vs lateral filaments differentiate local populations.
+
+**First major split:**
+
+- **Terradraconiformes** (wingless, armored burrowers).
+- **Aero‑capable lineages** with proto‑patagia (membranous skin between limb and flank) exposed by warm pulses during limb‑bud windows.
+
+### 201–145 Ma (Early–Mid Jurassic): From gliding to true sky
+
+**Nest engineering + cliffs:** Cave systems with vented skylights create vertical relief; gliding pays.
+
+**Plasticity → selection → lock‑in:** Repeated warm pulses during limb‑bud development elongate forelimbs and expand patagia; over generations cis‑regulatory changes near Prx1, Shh, FGF modules lock in longer stylopods/zeugopods and broad membranes.
+
+**Clade outcomes:**
+
+- **Aerodraconidae (Gliders):** broad patagia, robust claws; still mostly subterranean, foraging at cave mouths at dusk.
+- **Terradraconidae (Iron‑plates):** canalized heavy scutes; cooler favored nests; powerful forequarters for digging; glandular systems remain modest.
+
+### 145–100 Ma (Late Jurassic–Early Cretaceous): Hot sprays become weapons
+
+**Glands go from deterrent to offense:** Recurrent warm pulses in the gland‑primordia window enlarge ducts/secretory epithelia; nest microbiomes seed specialized symbionts. Selection favors lines that eject hot, caustic, sometimes luminous aerosols (bombardier‑style exothermy analogs).
+
+**Genomic signatures:** Tandem duplication of secretory enzyme genes; regulatory rewiring for cranial gland development; olfactory receptor expansions support targeting prey above ground.
+
+**Clade outcomes:**
+
+- **Pyrodraconidae (Heatjets):** wingless/subwinged, heavy cranial/gular glands, intimidatory displays in cave fights.
+- **Aerodraconidae split again:** some lines trade armor for lighter frames and larger thoraces → **Volucridraconidae (True fliers)**—an independent origin of powered flight within synapsids.
+
+### 100–66 Ma (Late Cretaceous): Peak diversity, different dials
+
+**Thermal dials diversify by habitat:**
+
+- **Coastal vents & sea caves:** warm, humid → **Thalassodraconidae** (semi‑aquatic cliff gliders) with salt‑handling glands; flexible scales for hydrodynamics.
+- **Highland lava tubes:** dry, variable → Pyrodraconids with dense gland lobes and heat‑tolerant mucosa.
+- **Temperate karst belts:** cool, stable → Terradraconids with true plate‑like osteoderms.
+
+**Sex systems diverge:** Lines in thermally predictable caves keep TSD overrides (parents control sex via nest depth); lines in variable climates re‑fortify GSD to avoid sex‑ratio crashes.
+
+### 66–34 Ma (Paleocene–Eocene): Survive the asteroid, surf the heat
+
+**K–Pg bottleneck:** Subterranean nesting again buffers extinction; small‑bodied, flexible‑diet forms are overrepresented among survivors.
+
+**Eocene heat:** Warmer caves push female bias in TSD clades; demographic stress selects for modifier alleles that narrow the thermosensitive window or shift the pivotal temperature—microevolution at the sex‑pathway’s epigenetic switch.
+
+**Flight refinement:** True fliers refine pneumatization and elastic thoraces; selection on patagial collagen/elastin matrices improves flapping efficiency.
+
+### 34–5 Ma (Oligocene–Miocene): Cooling world, new shapes
+
+**Cooling & aridification:**
+
+- **Cryodraconidae (Frost wyrms):** repeated cool‑window incubation favors dense filamentous coverings (placode bias → hair‑like integument); keratin gene regulation assimilates this insulation.
+- **Steppe/karst specialists:** lighter armor, cursorial limbs.
+
+**Gland divergence:** some lose heat‑jet capacity (energetically costly) and specialize in stinging or blinding sprays; others upscale heatjets toward brief, spectacular “torch” bursts for predator deterrence.
+
+### 2.6 Ma–present (Pleistocene–Holocene): Cycles and mosaics
+
+**Glacial–interglacial seesaw:** Bergmann clines, island gigantism in sea‑cave forms, dwarfism in inland karst pockets.
+
+**Human pressure:** Secretive, nocturnal surface foraging; nest‑master cultures in social clades perfect vent‑management traditions—cultural control of incubation dials stabilizes sex ratios and trait expression, reducing drift.
+
+## Distinct “dragon” lineages at present (examples)
+
+- **Terradraco ferrosquamatus (Iron‑plate Burrower)**
+  - *Winged?* No. *Fire?* Rare, low‑energy spray.
+  - *Signature:* Osteoderm‑reinforced scutes; powerful digging limbs; low‑O₂ tolerance.
+  - *Incubation strategy:* Cool set‑points, high CO₂; GSD dominant (minimizes sex‑ratio risk).
+  - *Assimilated modules:* Keratin/thick scale program; hypoxia‑tolerant lung development.
+- **Aerodraco planipatagium (Rift Glider)**
+  - *Winged?* Gliding membranes; *Fire?* Minimal.
+  - *Signature:* Wide patagia from forearm to flank; dusk cliff forager.
+  - *Incubation strategy:* Slight warm pulses during limb‑bud window; variable humidity to keep membranes supple.
+  - *Assimilated modules:* Prx1/FGF enhancer shifts for limb length; patagial ECM genes.
+- **Volucridraco kimmeridgensis (True Sky‑Dragon)**
+  - *Winged?* Yes—powered flight (synapsid origin). *Fire?* Light display only.
+  - *Signature:* Pneumatized skeleton; large sternum; elastic patagia.
+  - *Incubation strategy:* Tightly controlled warm means; narrow variance to avoid malformed wings.
+  - *Assimilated modules:* Thoracic remodeling, sustained aerobic capacity.
+- **Pyrodraco exothermis (Heatjet Drake)**
+  - *Winged?* Rudimentary or none. *Fire?* Yes—brief exothermic jets.
+  - *Signature:* Massive cranial/gular glands; thermal display organs; thick orofacial keratin.
+  - *Incubation strategy:* Warm mid‑incubation pulses targeting gland primordia; microbiome‑rich nest linings.
+  - *Assimilated modules:* Enlarged secretory lobes, duct architecture, enzyme‑regulatory networks.
+- **Thalassodraco halitus (Sea‑Cave Drake)**
+  - *Winged?* Glider. *Fire?* Salt‑spray irritant with heat shimmer.
+  - *Signature:* Salt glands; streamlined scales; cliff‑to‑sea glides.
+  - *Incubation strategy:* High humidity, salt‑laden nests; mild warm pulses for salt glands.
+  - *Assimilated modules:* Ion transporter regulation; hydrophobic scale microstructure.
+- **Cryodraco nivalis (Frost Wyrm)**
+  - *Winged?* Reduced patagia; *Fire?* None; cold‑light bioluminescence common.
+  - *Signature:* Dense filamentous pelage; counter‑current heat exchangers.
+  - *Incubation strategy:* Cool means; prolonged development; high O₂ flow to offset slow metabolism.
+  - *Assimilated modules:* Placode → hairlike program; mitochondrial efficiency genes.
+
+## How incubation sculpted each module (cause → effect → lock‑in)
+
+**Integument (scales ↔ spines ↔ filaments):**
+Thermal windows bias Wnt/BMP/EDA timing → more/less placodes, altered spacing → thicker scutes (cooler) vs fringes/filaments (warmer). Repeated selection in those microclimates expands keratin gene families and hardens regulatory timing → stable armor or insulation programs.
+
+**Glands (from deterrent to “fire‑like”):**
+Warm pulses grow gland primordia and duct complexity; nest microbiomes seed metabolic pathways. Lines that deter predators with hot sprays win; duplications in secretory enzymes and altered epithelial patterning canalize large, multi‑lobed glands and controlled discharge.
+
+**Limbs & patagia (glide → flight):**
+Warm pulses during limb‑bud growth extend forelimb growth periods and patagial area. Success of longer‑limb morphs drives cis‑regulatory tweaks near limb/ECM genes; muscle insertion patterns and sternum morphology follow. Over time, wingbeat‑ready thoraces and elastic membranes fix the once‑plastic changes.
+
+**Lungs & metabolism (hypoxia specialists):**
+Burrow hypoxia + heat raises O₂ demand; embryos incubated with enhanced ventilation develop larger air spaces and efficient capillary networks. Selection fixes HIF‑axis modifiers and surfactant timing—a subterranean advantage that later also supports flight in aerial clades.
+
+**Sex determination (demography control):**
+Hybrid GSD↔TSD evolves early via temperature‑sensitive epigenetic switches; stable caves keep TSD lines viable (parents “dial” sex via egg placement), while variable climates re‑strengthen GSD. Modifiers (pivotal temperature shifts, window width) evolve under Eocene warming pressure.
+
+## Why this works over 300 Myr
+
+**Plasticity‑first is fast:** You don’t need new genes at first—incubation reveals phenotypes immediately.
+
+**Selection is consistent:** Caves and geothermal vents are predictable; nest‑masters reproduce the same microclimate biases each generation.
+
+**Assimilation is cumulative:** Small regulatory changes accumulate—keratin clusters expand, limb enhancers drift, glandular networks duplicate—so formerly induced traits become defaults.
+
+**Crises favor caves:** After each cataclysm (P–T, end‑Triassic, K–Pg), subterranean breeders rebound first, carrying their incubation‑tuned innovations forward.
+
+## “Field signals” a paleontologist would find
+
+- Eggshell series showing increasing pore specialization and antimicrobial cuticles across time.
+- Nest traces (vent shafts, compost layers, fumarole chimneys) recurring in the same formations.
+- Staged shifts in dermal element histology (from flexible scales → osteoderms → laminar scutes; or to filament bases).
+- Cranial canal/foramen remodeling for gland ducts in Pyrodraconids.
+- Forelimb proportions and sternal keel growth in Aerodraconid/Volucridraconid lines.
+- Isotopic signatures of hypoxia‑tolerant growth in bone microstructure.
+
+**TL;DR**
+
+Give a lineage control over incubation microclimate for hundreds of millions of years and you get a plasticity‑first engine that repeatedly generates useful morphs (armor, glands, membranes, insulation, sex‑ratio control). Natural selection then writes those morphs into the genome. The result is a radiation of dragons—armored burrowers, heat‑jet drakes, cliff gliders, true fliers, sea‑cave specialists, frost wyrms—each traceable to the same set of knobs: mean temperature, variance/pulses, humidity, and O₂/CO₂ during narrow developmental windows.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Use the table below to jump directly to material for a given region and theme.
 Additional folders explore broader or supporting topics:
 
 - [Dragon Mechanics](Dragon%20Mechanics/README.md) – movement, anatomy, and combat of dragons
+- [Evolutionary Arc of Dragons](Dragon%20Mechanics/evolutionary-arc.md) – plasticity‑first lineage from subterranean synapsids to modern dragons
 - [Bombardier Beetle Spray Mechanism](bombardier-beetle-spray-mechanism/README.md) – natural chemical defenses for inspiration
 - [Megaliths](megaliths/README.md) – catalogue of global megalithic structures
 

--- a/bombardier-beetle-spray-mechanism/README.md
+++ b/bombardier-beetle-spray-mechanism/README.md
@@ -15,4 +15,7 @@ Displacement of specialized cuticular structures at the junction between the res
 - [`abstract.md`](./abstract.md) – summary of the paper's abstract.
 - [`main-text/`](./main-text/) – thematic sections covering background, anatomy, spray dynamics, experimental approaches, and results.
 - [`data/`](./data/) – Markdown tables and figure descriptions drawn from the manuscript.
+
 - [`references.md`](./references.md) – list of cited works.
+
+This biological mechanism parallels the glandular heat‑jet systems in dragons described in the [Evolutionary Arc of Dragons](../Dragon%20Mechanics/evolutionary-arc.md).


### PR DESCRIPTION
## Summary
- add comprehensive 300-million-year evolutionary arc for dragon origins
- cross-link evolutionary framework from root README and Dragon Mechanics
- reference dragon heat-jet glands in bombardier beetle research

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acba955edc832d91786a3b99cbb0a9